### PR TITLE
Added regSize and regAddrSize arguments to I2CSlave class constructor…

### DIFF
--- a/src/I2CSlaveRK.cpp
+++ b/src/I2CSlaveRK.cpp
@@ -4,10 +4,10 @@
 
 static I2CSlave *globalObj = 0;
 
-I2CSlave::I2CSlave(TwoWire &wire, uint8_t addr, size_t numRegisters) :
-		wire(wire), addr(addr), numRegisters(numRegisters),
-		nextReadAddr(0), registerSetFlags(0) {
-	registers = (uint32_t *)malloc(numRegisters * sizeof(uint32_t));
+I2CSlave::I2CSlave(TwoWire &wire, uint8_t addr, size_t numRegisters, I2C_Reg_Size_t regSize, I2C_Reg_Addr_Size_t regAddrSize) :
+		wire(wire), addr(addr), regSize(regSize), regAddrSize(regAddrSize), 
+		numRegisters(numRegisters), nextReadAddr(0), registerSetFlags(0) {
+	registers = (uint8_t *)malloc(numRegisters * regSize);
 	globalObj = this;
 }
 
@@ -24,17 +24,31 @@ void I2CSlave::begin() {
 }
 
 uint32_t I2CSlave::getRegister(uint16_t regAddr) const {
-	if (regAddr < numRegisters) {
-		return registers[regAddr];
-	}
-	else {
+	if (regAddr >= numRegisters) {
 		return 0;
 	}
+	uint32_t value = registers[regAddr * regAddrSize];
+	if (regSize > REG_SIZE_8) {
+		value |= (registers[regAddr * regAddrSize + 1] << 8);
+	}
+	if (regSize == REG_SIZE_32) {
+		value |= (registers[regAddr * regAddrSize + 2] << 16);
+		value |= (registers[regAddr * regAddrSize + 3] << 24);
+	}
+	return value;
 }
 
 void I2CSlave::setRegister(uint16_t regAddr, uint32_t value) {
-	if (regAddr < numRegisters) {
-		registers[regAddr] = value;
+	if (regAddr >= numRegisters) {
+		return;
+	}
+	registers[regAddr * regAddrSize] = value & 0xff;
+	if (regSize > REG_SIZE_8) {
+		registers[regAddr * regAddrSize + 1] = (value >> 8) & 0xff;
+	}
+	if (regSize == REG_SIZE_32) {
+		registers[regAddr * regAddrSize + 2] = (value >> 16) & 0xff;
+		registers[regAddr * regAddrSize + 3] = (value >> 24) & 0xff;
 	}
 }
 
@@ -55,44 +69,75 @@ bool I2CSlave::getRegisterSet(uint16_t &regAddr) {
 	}
 }
 
+// [static]
+uint32_t regSizeMask(I2C_Reg_Size_t regSize) {
+	switch (regSize) {
+		case REG_SIZE_8:  return 0xff;
+		case REG_SIZE_16: return 0xffff;
+		default:          return 0xffffffff;
+	}
+}
+
+// [static]
+uint16_t regAddrSizeMask(I2C_Reg_Addr_Size_t regAddrSize) {
+	switch (regAddrSize) {
+		case REG_ADDR_SIZE_8: return 0xff;
+		default:              return 0xffff;
+	}
+}
+
 
 void I2CSlave::receiveEvent(int numBytes) {
-
-	if (numBytes == sizeof(uint16_t)) {
+	if (numBytes == regAddrSize) {
 		// This is just an  address to read the register. Save for requestEvent.
 		nextReadAddr = (wire.read() & 0xff);
-		nextReadAddr |= (wire.read() & 0xff) << 8;
-	}
-	else
-	if (numBytes == (sizeof(uint16_t) + sizeof(uint32_t))) {
-		// Set a register
-		uint16_t writeAddr = (wire.read() & 0xff);
-		writeAddr |= (wire.read() & 0xff) << 8;
-
-		uint32_t value = (wire.read() & 0xff);
-		value |= (wire.read() & 0xff) << 8;
-		value |= (wire.read() & 0xff) << 16;
-		value |= (wire.read() & 0xff) << 24;
-
-		if (writeAddr < numRegisters) {
-			registers[writeAddr] = value;
-
-			if (writeAddr < 32) {
-				registerSetFlags |= 1 << writeAddr;
-			}
+		if (regAddrSize == REG_ADDR_SIZE_16) {
+			nextReadAddr |= (wire.read() & 0xff) << 8;
 		}
 	}
+	else
+	if (numBytes == (regAddrSize + regSize)) {
+		// Set a register
+		uint16_t writeAddr = (wire.read() & 0xff);
+		if (regAddrSize == REG_ADDR_SIZE_16) {
+			writeAddr |= (wire.read() & 0xff) << 8;
+		}
 
+		// If address is out of range, read and discard
+		if (writeAddr >= numRegisters) {
+			for(int i=0; i<regSize; i++){
+				wire.read();
+			}
+			return;
+		}
+
+		// Read variable number of bytes
+		registers[writeAddr * regAddrSize] = (wire.read() & 0xff);
+		if (regSize > REG_SIZE_8) {
+			registers[writeAddr * regAddrSize + 1] = (wire.read() & 0xff);
+		}
+		if (regSize == REG_SIZE_32) {
+			registers[writeAddr * regAddrSize + 2] = (wire.read() & 0xff);
+			registers[writeAddr * regAddrSize + 3] = (wire.read() & 0xff);
+		}
+
+		// Set register flag
+		if (writeAddr < 32) {
+			registerSetFlags |= 1 << writeAddr;
+		}
+	}
 }
 
 void I2CSlave::requestEvent() {
 	// Request to read
-	uint32_t value = 0;
-
-	if (nextReadAddr < numRegisters) {
-		value = registers[nextReadAddr];
+	if (nextReadAddr >= numRegisters) {
+		// Address out of range, return zeroes.
+		const uint8_t zeroes[regSize] = {};
+		wire.write(zeroes, regSize);
 	}
-	wire.write((const uint8_t *)&value, sizeof(value));
+	else {
+		wire.write(registers + (nextReadAddr * regSize), regSize);
+	}
 }
 
 // [static]


### PR DESCRIPTION
Added support for slave mode with 1-, 2-, or 4-byte registers, and 1- or 2-byte register addresses.

Allows a wider range of sensors to be emulated.

Fixes #2